### PR TITLE
Normalize CircleCI 2.0 build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,43 @@
+aliasses:
+  - &step_restore_vendor_cache
+    restore_cache:
+      keys:
+        - birdspotting-vendor-{{ .Branch }}-{{ .Revision }}
+        - birdspotting-vendor-{{ .Branch }}
+        - birdspotting-vendor-
+  - &step_save_vendor_cache
+    save_cache:
+      key: birdspotting-vendor-{{ .Branch }}-{{ .Revision }}
+      paths: [ vendor/bundle ]
+
+
 version: 2
+
 jobs:
-  build:
+  test:
     docker:
-      - image: drivy/rails-ci:0.1.2
+      - image: circleci/ruby:2.4-jessie-node
     steps:
       - checkout
-
-      - run: git fetch origin --depth=1000
-
-      # Install CodeClimate test reporter binary, rebuild without cache to update the binary
-      - restore_cache:
-          key: cc_test_reporter
-      - run:
-          name: Install Code Climate test reporter
-          command: |
-            [ -f bin/cc-test-reporter ] || curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./bin/cc-test-reporter
-            chmod +x bin/cc-test-reporter
-      - restore_cache:
-          key: cc_test_reporter
-          paths:
-            - bin/cc-test-reporter
-
-      - run:
-          name: "Creating a Gemfile.lock without bundler's version"
-          command: "head -n -3 Gemfile.lock > Gemfile.lock.no-version"
-
-      # Bundle install with cache, Ignore bundler version
-      - restore_cache:
-          key: timed_deprecation-{{ checksum "Gemfile.lock.no-version"}}
+      - *step_restore_vendor_cache
       - run:
           name: Install Ruby dependencies
-          command: bundle install --path vendor/bundle --jobs=`nproc`
-      - save_cache:
-          key: timed_deprecation-{{ checksum "Gemfile.lock.no-version"}}
-          paths:
-            - vendor/bundle
-
+          command: bundle install --path vendor/bundle --jobs=2
+      - *step_save_vendor_cache
       - run:
-          name: RSpec
+          name: Run RSpec suite
           command: |
-            ./bin/cc-test-reporter before-build
-            bundle exec rspec --format documentation
-            ./bin/cc-test-reporter after-build --exit-code $?
+            bundle exec rspec \
+              --format progress \
+              --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+          environment:
+            RAILS_ENV: test
+      - store_test_results:
+          path: /tmp/test-results
+
+workflows:
+  version: 2
+
+  test:
+    jobs:
+      - test

--- a/birdspotting.gemspec
+++ b/birdspotting.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "rspec_junit_formatter"
 
   spec.add_runtime_dependency "activerecord", ">= 5.0"
 end


### PR DESCRIPTION
# What to expect

 - Code CI 101: install bundles and run the tests
 - Cache bundles (by commit,branch) in the CI cache
 - Adds the `rspec_junit_formatter` spec to allow test result integration in CircleCI
![screen shot 2018-09-13 at 16 13 58](https://user-images.githubusercontent.com/19536759/45493862-0b621e80-b770-11e8-9078-5a634cb7f07d.png)
