### PR TITLE
Add support from Rails 5.2 to Rails <6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    birdspotting (0.1.3)
-      activerecord (~> 6.0.2.1)
+    birdspotting (0.1.4)
+      activerecord (>= 5.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.2.1)
-      activesupport (= 6.0.2.1)
-    activerecord (6.0.2.1)
-      activemodel (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-    activesupport (6.0.2.1)
+    activemodel (6.0.3.5)
+      activesupport (= 6.0.3.5)
+    activerecord (6.0.3.5)
+      activemodel (= 6.0.3.5)
+      activesupport (= 6.0.3.5)
+    activesupport (6.0.3.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.12.2)
@@ -42,7 +42,7 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
-    i18n (1.8.2)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     listen (3.2.1)
@@ -50,7 +50,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.4)
     method_source (0.9.2)
-    minitest (5.14.0)
+    minitest (5.14.3)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -98,10 +98,10 @@ GEM
     simplecov-html (0.11.0)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    zeitwerk (2.2.2)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/birdspotting.gemspec
+++ b/birdspotting.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "simplecov"
 
-  spec.add_runtime_dependency "activerecord", "~> 6.0.2.1"
+  spec.add_runtime_dependency "activerecord", ">= 5.2", "< 6.1"
 end

--- a/lib/birdspotting/version.rb
+++ b/lib/birdspotting/version.rb
@@ -1,3 +1,3 @@
 module Birdspotting
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.4".freeze
 end


### PR DESCRIPTION
## Associated issue: https://github.com/drivy/drivy-rails/issues/23298

## What this PR does

- Add support from Rails 5.2 to be usable from our current `drivy-rails` app
- Add support to Rails <6.1 to be ready for our `drivy-rails` Rails 6 upgrade
- Bump version to `0.1.4`

Bumping version to a major doesn't look necessary to me as this PR doesn't introduce a breaking change, as the ol and new versions of `drivy-rails` should still be supported.

## Tests

### Current Rails 5 app

I created a PR to test several migrations that should either fail or log warning: https://github.com/drivy/drivy-rails/pull/27253

### Next Rails 6 app

I created a PR to test several migrations that should either fail or log warning: https://github.com/drivy/drivy-rails/pull/27254

## Conclusion

Every expected error and warning is raised at the expected moments.