### PR TITLE
Add support for Rails 7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    birdspotting (0.1.6)
-      activerecord (>= 6.0, < 7.0)
+    birdspotting (0.1.7)
+      activerecord (>= 6.1, < 7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/birdspotting.gemspec
+++ b/birdspotting.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "simplecov"
 
-  spec.add_runtime_dependency "activerecord", ">= 6.0", "< 7.0"
+  spec.add_runtime_dependency "activerecord", ">= 6.1", "< 7.1"
 end

--- a/lib/birdspotting/version.rb
+++ b/lib/birdspotting/version.rb
@@ -1,3 +1,3 @@
 module Birdspotting
-  VERSION = "0.1.6".freeze
+  VERSION = "0.1.7".freeze
 end


### PR DESCRIPTION
## Links
  🚧   [Issue](https://github.com/drivy/drivy-rails/issues/32442)

## Context
We're upgrading our `drivy-rails` Rails version to Rails `7.0`

This PR aims to change the supported rails version:
- Limits support to superior or equal to Rails `6.1` to be keep it usable with our current `drivy-rails` app
- Extends support to Rails strictly inferior to 7.1 to prepare for our `drivy-rails` Rails 7.0 upgrade
- Bumps gem version to `0.1.7`

## Tests
### Rails 6.1
WIP - [This PR](https://github.com/drivy/drivy-rails/pull/32648) tests that several migrations should either fail or trigger a warning

### rails 7.0
WIP - [This PR](https://github.com/drivy/drivy-rails/pull/32651) tests that several migrations should either fail or trigger a warning

## Conclusion
WIP - Every expected error and warning is raised at the expected moments.