### PR TITLE
Support Rails 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     birdspotting (0.1.9)
-      activerecord (>= 6.1, < 8.0)
+      activerecord (>= 7.2, < 8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/birdspotting.gemspec
+++ b/birdspotting.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "simplecov"
 
-  spec.add_runtime_dependency "activerecord", ">= 6.1", "< 8.0"
+  spec.add_runtime_dependency "activerecord", ">= 7.2", "< 8.1"
 end


### PR DESCRIPTION
## Links
  💎   Rails 8 PR: https://github.com/drivy/drivy-rails/pull/49412

## Context
We're planning on upgrading our `drivy-rails` Rails version to Rails `8.0`

This PR:
- Limits support to superior or equal to Rails `7.2` to keep it usable with our current `drivy-rails` app
- Extends support to Rails strictly inferior to 8.1 to prepare for our `drivy-rails` Rails 8.0 upgrade
- Bumps gem version to `0.1.10`

## Tests
### Rails 7.2
[This PR](https://github.com/drivy/drivy-rails/pull/49456) tests that several migrations should either fail or trigger a warning

### Rails 8.0
[This PR](https://github.com/drivy/drivy-rails/pull/49457) tests that several migrations should either fail or trigger a warning

## Conclusion
Every expected error and warning is raised at the expected moment